### PR TITLE
Obsidian timeline fixes

### DIFF
--- a/src/watcher/watcher.worker.ts
+++ b/src/watcher/watcher.worker.ts
@@ -399,7 +399,7 @@ class Parser {
             let datebits = element.dataset.date.split(/(?<!^)-/);
             const date = {
                 year: parseInt(datebits[0]),
-                month: parseInt(datebits[1]),
+                month: parseInt(datebits[1])-1,
                 day: parseInt(datebits[2])
             };
             let end;
@@ -407,7 +407,7 @@ class Parser {
                 datebits = element.dataset.end.split(/(?<!^)-/);
                 end = {
                     year: parseInt(datebits[0]),
-                    month: parseInt(datebits[1]),
+                    month: parseInt(datebits[1])-1,
                     day: parseInt(datebits[2])
                 };
             }

--- a/src/watcher/watcher.worker.ts
+++ b/src/watcher/watcher.worker.ts
@@ -55,7 +55,7 @@ export type RenameMessage = {
     file: { path: string; basename: string; oldPath: string };
 };
 
-const timelineData: RegExp = /(<(span|div)(?s:.)*?<\/(span|div)>)/g;
+const timelineData: RegExp = /(<(span|div)[\S\s]*?<\/(span|div)>)/g;
 const ctx: Worker = self as any;
 class Parser {
     queue: string[] = [];

--- a/src/watcher/watcher.worker.ts
+++ b/src/watcher/watcher.worker.ts
@@ -55,7 +55,7 @@ export type RenameMessage = {
     file: { path: string; basename: string; oldPath: string };
 };
 
-const timelineData: RegExp = /(<(span|div).*?<\/(span|div)>)/g;
+const timelineData: RegExp = /(<(span|div)(?s:.)*?<\/(span|div)>)/g;
 const ctx: Worker = self as any;
 class Parser {
     queue: string[] = [];


### PR DESCRIPTION
-Fixed regex used to parse "Timeline" plugin <span> tags to allow for new line characters.
-Fixed issue with parsing of events from the "Timeline" plugin setting the month wrong.