### PR TITLE
fc-date parsing for timeline span/div tags

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,6 @@
 # 4 space indentation
 indent_style = space
 indent_size = 4
+
+[*.ts]
+    trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ webpack.dev.js
 main.js.LICENSE.txt
 
 .env
+build

--- a/src/@types/api.d.ts
+++ b/src/@types/api.d.ts
@@ -1,10 +1,10 @@
 import {
     Moon,
     Phase,
-    Event,
+    FcEvent,
     CurrentCalendarData,
     LeapDay,
-    EventCategory
+    FcEventCategory
 } from ".";
 
 declare class API {
@@ -28,14 +28,14 @@ declare class API {
     ): Day;
 
     addCategoryToCalendar(
-        category: EventCategory,
+        category: FcEventCategory,
         calendar: Calendar | string = this.plugin.defaultCalendar
     ): Promise<void>;
 }
 
 export type Day = {
     moons: [Moon, Phase][];
-    events: Event[];
+    events: FcEvent[];
     date: CurrentCalendarData;
     longDate: {
         day: number;

--- a/src/@types/calendar.d.ts
+++ b/src/@types/calendar.d.ts
@@ -17,6 +17,7 @@ export interface Calendar {
     supportTimelines: boolean;
     syncTimelines: boolean;
     timelineTag: string;
+    dateFormat?: string;
 }
 export interface StaticCalendarData {
     firstWeekDay: number;
@@ -65,7 +66,7 @@ interface LeapDayCondition {
 
 /**
 Example Condition
-  
+
 400,!100,4 - Every 4 years, unless it is divisible by 100, but again if it is divisible by 400.
 
 [

--- a/src/@types/calendar.d.ts
+++ b/src/@types/calendar.d.ts
@@ -1,5 +1,5 @@
 import { Moon } from ".";
-import { Event, EventCategory } from ".";
+import { FcEvent, FcEventCategory } from ".";
 
 export interface Calendar {
     id: string;
@@ -8,8 +8,8 @@ export interface Calendar {
     static: StaticCalendarData;
     current: CurrentCalendarData;
     _current?: CurrentCalendarData;
-    events: Event[];
-    categories: EventCategory[];
+    events: FcEvent[];
+    categories: FcEventCategory[];
     date?: number;
     displayWeeks?: boolean;
     autoParse: boolean;

--- a/src/@types/event.d.ts
+++ b/src/@types/event.d.ts
@@ -1,4 +1,4 @@
-export interface Event {
+export interface FcEvent {
     name: string;
     description: string;
     date: {
@@ -26,14 +26,14 @@ interface FormulaInterval {
     timespan: "days";
 }
 
-export interface ColorEvent extends Event {
+export interface ColorEvent extends FcEvent {
     color: string;
 }
 
-export interface EventCategory {
+export interface FcEventCategory {
     name: string;
     color: string;
     id: string;
 }
 
-export interface EventCondition {}
+export interface FcEventCondition {}

--- a/src/@types/event.d.ts
+++ b/src/@types/event.d.ts
@@ -1,22 +1,26 @@
+import { Nullable } from ".";
+
+export interface FcEventSort {
+    timestamp: number;
+    order: string;
+}
+export interface FcEventDate {
+    year: Nullable<number>,
+    month: Nullable<number>,
+    day: Nullable<number>
+}
+
 export interface FcEvent {
     name: string;
     description: string;
-    date: {
-        month: number;
-        day: number;
-        year: number;
-    };
-    end?: {
-        month: number;
-        day: number;
-        year: number;
-    };
+    date: FcEventDate;
+    end?: FcEventDate;
     id: string;
     note: string;
     category: string;
-    timestamp?: number;
-    auto?: boolean;
+    sort: FcEventSort;
     formulas?: EventFormula[];
+    img?: string;
 }
 
 type EventFormula = FormulaInterval;

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,11 +1,10 @@
-import type { Recurring } from "src/settings/settings";
-
 export * from "./calendar";
-export * from "./leapday";
 export * from "./event";
 export * from "./moons";
 
 import type { Calendar } from "./calendar";
+
+export type Nullable<T> = T | null;
 
 export interface FantasyCalendarData {
     addToDefaultIfMissing: boolean;

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -2,7 +2,7 @@ import { Notice } from "obsidian";
 import type {
     Calendar,
     CurrentCalendarData,
-    EventCategory,
+    FcEventCategory,
     Moon,
     Phase
 } from "src/@types";
@@ -132,7 +132,7 @@ export class API implements APIDefinition {
     }
 
     async addCategoryToCalendar(
-        category: EventCategory,
+        category: FcEventCategory,
         calendar: Calendar | string = this.plugin.defaultCalendar
     ) {
         if (!category) {

--- a/src/helper/event.helper.ts
+++ b/src/helper/event.helper.ts
@@ -1,0 +1,487 @@
+import type { FrontMatterCache } from "obsidian";
+import { nanoid, wrap } from "../utils/functions";
+const { DOMParser } = require("xmldom");
+import type {
+    Calendar,
+    FcEvent,
+    FcEventCategory,
+    FcEventDate,
+    FcEventSort,
+    LeapDay,
+    Nullable
+} from "../@types";
+
+const timelineData: RegExp = /<(span|div)[\s\S]*?<\/(span|div)>/g;
+
+export type FcEventCallback = (fcEvent: FcEvent) => void;
+
+export interface InputDate {
+    year?: any,
+    month?: any,
+    day?: any,
+    order?: any
+}
+
+export interface ParseDate {
+    year: Nullable<number>,
+    month: Nullable<number>,
+    day: Nullable<number>,
+    order: string
+}
+
+export class FcEventHelper {
+    calendar: Calendar;
+    useFilenameForEvents: boolean;
+    formatString: string;
+    formatDigest: string;
+    padMonth: number;
+    padDays: number;
+
+    /**
+     * Creates an instance of EventHelper.
+     * @param {Calendar} calendar
+     */
+    constructor(calendar: Calendar, parseTitleForEvents: boolean, dateFormat: string) {
+        this.calendar = calendar;
+        this.useFilenameForEvents = parseTitleForEvents;
+        this.formatString = calendar.dateFormat || dateFormat;
+        this.formatDigest = this.formatString.toUpperCase()
+            .replace(/[^\w]/g, "")
+            .replace(/Y+/g, "Y")
+            .replace(/M+/g, "M")
+            .replace(/D+/g, "D");
+        console.log(this.formatString, this.formatDigest);
+        this.padMonth = (calendar.static.months.length + "").length;
+        this.padDays = (calendar.static.months.reduce((max, month)=> ( (max > month.length) ? max : month.length), 0) + "").length;
+    }
+
+    parseFileForEvents(
+        data: string,
+        file: { path: string; basename: string },
+        frontmatter: FrontMatterCache,
+        publish: FcEventCallback
+    ) {
+        let fcCategory: string;
+        console.log("#### parse file for events", frontmatter);
+        if (frontmatter) {
+            fcCategory = frontmatter?.["fc-category"];
+        }
+        const category = this.calendar.categories.find(
+            (cat) => cat?.name == fcCategory
+        );
+
+        // Single event in the frontmatter
+        this.parseFrontmatterEvent(
+            frontmatter,
+            file,
+            publish,
+            category
+        );
+
+        if (this.calendar.supportTimelines) {
+            this.parseTimelineEvents(
+                data,
+                file,
+                publish,
+                category
+            );
+        }
+    }
+
+    parseFrontmatterEvent(
+        frontmatter: FrontMatterCache,
+        file: { path: string; basename: string },
+        publish: FcEventCallback,
+        category?: FcEventCategory
+    ) {
+        const dateField = "fc-date" in frontmatter ? "fc-date" : "fc-start";
+        let date = frontmatter[dateField]
+            ? this.parseFrontmatterDate(frontmatter[dateField], file)
+            : this.useFilenameForEvents ? this.parseFilenameDate(file) : null;
+
+        let end = frontmatter["fc-end"]
+            ? this.parseFrontmatterDate(frontmatter["fc-end"], file)
+            : null;
+
+        if (date) {
+            publish({
+                id: nanoid(6),
+                name: frontmatter["fc-display-name"] ?? file.basename,
+                description: frontmatter["fc-description"],
+                date,
+                end,
+                sort: this.parsedToTimestamp(date),
+                note: file.path,
+                category: category?.id,
+                img: frontmatter["fc-img"]
+            });
+        }
+    }
+
+    parseTimelineEvents(
+        contents: string,
+        file: { path: string; basename: string },
+        publish: FcEventCallback,
+        category?: FcEventCategory
+    ) {
+        const domparser = new DOMParser();
+        // span or div with attributes:
+        // <span
+        //     data-fc-date='144-Ches'      // mixed/short: year-...
+        //     data-fc-end='144-Ches-03-07' // mixed/full:
+        //     data-title='Another Event'
+        //     data-class='orange'
+        //     data-img = 'Timeline Example/Timeline_2.jpg'>
+        //     Event description
+        // </span>
+        // 4 segments: year-\d+-\d+-\d+ or year-monthName-\d+-\d+
+        // For repeating events, use *
+        for (const match of contents.matchAll(timelineData)) {
+            const doc = domparser.parseFromString(match[0], "text/html");
+            const element = {
+                dataset: {
+                    // Fantasy calendar mixed-date format
+                    fcDate: doc.documentElement.getAttribute("data-fc-date"),
+                    fcEnd: doc.documentElement.getAttribute("data-fc-end"),
+                    // timeline card attributes
+                    title: doc.documentElement.getAttribute("data-title"),
+                    class: doc.documentElement.getAttribute("data-category"),
+                    img: doc.documentElement.getAttribute("data-img"),
+                },
+                content: doc.documentElement.textContent
+            };
+            if (!element.dataset.fcDate) {
+                continue; // span must contain a date
+            }
+            // parse date strings, will return with all elements present: year, month, day, hour/order
+            let date = this.parseFcDateString(element.dataset.fcDate, file);
+            let end = element.dataset.fcEnd
+                    ? this.parseFcDateString(element.dataset.fcEnd, file)
+                    : undefined;
+
+            if (element.dataset.class) {
+                let cat = this.calendar.categories.find(
+                    (cat) => cat?.name == element.dataset.class
+                );
+                if (cat) {
+                    category = cat;
+                }
+            }
+
+            if (date) {
+                publish({
+                    id: nanoid(6),
+                    name: element.dataset.title ?? file.basename,
+                    description: element.content,
+                    date,
+                    end,
+                    sort: this.parsedToTimestamp(date),
+                    note: file.path,
+                    category: category?.id,
+                    img: element.dataset.img
+                });
+            }
+        }
+    }
+
+    parseFilenameDate(file: { path: string; basename: string }): ParseDate {
+        // TODO: Filename formatter for this calendar?
+        return this.parseFcDateString(file.basename, file);
+    }
+
+    parseFrontmatterDate(
+        date: string | InputDate,
+        file: { path: string; basename: string }
+    ): ParseDate {
+        if (typeof date === "string") {
+            return this.parseFcDateString(date, file);
+        }
+
+        // replace any missing segments with '*'
+        // to indicate a wildcard/repeating event
+        return this.dateFromSegments({
+                year: date.year || "*",
+                month: date.month || "*",
+                day: date.day || "*",
+                order: date.order
+            },
+            file
+        );
+    }
+
+    /**
+     * Date in segments starting with year:
+     * - year[-\d+[-\d+[-order]]]
+     * - year[-monthName[-\d+[-order]]]
+     *
+     * Notes:
+     * - '*' for repeating segment: year, month, and/or day
+     * - order is a simple string to determine the order of events
+     *   falling on the same year/month/day
+     *
+     * @param datestring
+     * @param file Source file
+     * @returns ParseDate instance
+     */
+    parseFcDateString(
+        datestring: string,
+        file: { path: string; basename: string }
+    ): ParseDate {
+        let datebits = datestring.split(/(?<!^)-/);
+
+        if (this.formatDigest != 'YMD' && datebits.length < 3) {
+            logError(`Must specify all three segments in ${this.formatString} order`, null, file, datestring);
+            return null;
+        }
+
+        return this.dateFromSegments({
+                year: datebits[this.formatDigest.indexOf("Y")] || null,
+                month: datebits[this.formatDigest.indexOf("M")] || null,
+                day: datebits[this.formatDigest.indexOf("D")] || null,
+                order: datebits[3] ? datebits[3] : ''
+            },
+            file,
+            datestring
+        );
+    }
+
+    /**
+     * Create a formatted date string for this calendar
+     * for the given event date (will not include an order suffix)
+     * @returns
+     */
+    toFcDateString(date: FcEventDate): string {
+        return this.formatString
+                .replace(/[Yy]+/g, `${date.year}`)
+                .replace(/[Mm]{3,}/g, toMonthString(date.month, this.calendar))
+                .replace(/[Mm]{2,}/g, toString(date.month + 1, this.padMonth)) // to human index
+                .replace(/[Mm]/g, `${date.month + 1}`)
+                .replace(/[Dd]{2,}/g, toString(date.day, this.padDays))
+                .replace(/[Dd]/g, `${date.day}`);
+    }
+
+    /**
+     * Create a fully formed date from parsed data segments
+     *
+     * @param input InputDate, * for repeating, null for omitted
+     * @param file Source file
+     * @param order Optional extra data to disambiguate or order events with the same date
+     * @param datestring Optional/original datestring
+     * @returns ParseDate instance
+     */
+    dateFromSegments(input: InputDate,
+            file: { path: string; basename: string },
+            datestring?: string
+    ): ParseDate {
+        const year = wildNullNumber(input.year);
+        let month = wildNullNumber(input.month);
+        let day = wildNullNumber(input.day);
+
+        if (input.year === "*") {
+            // repeating, this is fine
+        } else if ( !input.year || Number.isNaN(year)) {
+            logError(`Must specify a valid year`, input, file, datestring);
+            return null;
+        }
+
+        let leapday: LeapDay;
+        if (input.month === "*") {
+            // repeating, this is fine
+        } else if (Number.isInteger(month)) {
+            month = wrap(month - 1, this.calendar.static.months.length);
+        } else if (Number.isNaN(month)) {
+            // Name in the month segment
+            let m = this.calendar.static.months.find(
+                (m) => m.name.startsWith(input.month)
+            );
+            if (m) {
+                month = this.calendar.static.months.indexOf(m);
+            } else {
+                // Is this a well-known leapday?
+                leapday = this.calendar.static.leapDays.find(
+                    (l) => l.name.startsWith(input.month)
+                );
+                if (leapday) {
+                    month = leapday.timespan;
+                }
+            }
+        } else {
+            // short form (omitted), assume first month
+            month = 0;
+        }
+
+        if (input.day === "*") {
+            // repeating, this is fine
+        } else if ( Number.isInteger(day) ) {
+            if ( day < 1 ) {
+                logWarning(`Must specify a valid day. Using 1`, input, file, datestring);
+                day = 1
+            } else if (month) { // validate the day against the month (and perhaps year)
+                const days = this.daysForMonth(month, year);
+                if (day > days) {
+                    logError(`Day '${input.day}' is incorrect for month '${input.month}', which has ${days} day(s)`,
+                            input, file, datestring);
+                    return null;
+                }
+            }
+        } else if (leapday) {
+            // short form (omitted date), but a well-known leapday (e.g. Harptos Shieldmeet)
+            day = this.findLeapDay(leapday, month, year);
+            if (day == null) {
+                logError(`Leap day '${input.day}' isn't valid for year '${input.year}'`, input, file, datestring);
+                return null;
+            } else if (!year && input.year !== "*") {
+                logWarning(`Unable to validate '${input.day}' for year '${input.year}'. Using ${day}`, input, file, datestring);
+            }
+        } else {
+            // short form, assume first day of month
+            day = 1;
+        }
+
+        return {
+            year,
+            month,
+            day,
+            order: input.order || '',
+        };
+    }
+
+    parsedToTimestamp(date: ParseDate): FcEventSort {
+        // put repeating events off to the side
+        if (date.year == null || date.month == null || date.day == null) {
+            return {
+                timestamp: Number.MIN_VALUE,
+                order: date.order ? date.order
+                    : `${date.year || "*" }-${toString(date.month, this.padMonth)}-${toString(date.day, this.padDays)}`
+            }
+        }
+        // otherwise create a date string
+        // TODO: pad month by number of months & days by max days
+        return {
+            timestamp: Number(`${date.year}${toString(date.month, this.padMonth)}${toString(date.day, this.padDays)}`),
+            order: date.order || ''
+        };
+    }
+
+    timestampForFcEvent(event: Partial<FcEvent>, old?: FcEventSort): FcEventSort {
+        if (!old && event.sort) {
+            return event.sort;
+        }
+        // rebuild the timestamp
+        return this.parsedToTimestamp({
+            ...event.date,
+            order: old?.order || ''
+        });
+    }
+
+    /**
+     * Find day in month
+     */
+    findLeapDay(
+        leapday: LeapDay,
+        month: number,
+        year: number
+    ): Nullable<number> {
+        const cm = this.calendar.static.months[month];
+        const leapdays: LeapDay[] = this.calendar.static.leapDays.filter(
+            (l) => l.timespan == month && !l.intercalary || (l.intercalary && l.numbered)
+        );
+        if (year && !this.testLeapDay(leapday, year)) {
+            return null;
+        }
+        const day = cm.length + leapdays.indexOf(leapday) + 1;
+        return day;
+    }
+
+    /**
+     * Get the number of days in a month
+     */
+    daysForMonth(month: number, year: Nullable<number>): number {
+        const cm = this.calendar.static.months[month];
+        const leapdays: LeapDay[] = this.calendar.static.leapDays.filter(
+            (l) => l.timespan == month && !l.intercalary || (l.intercalary && l.numbered)
+        );
+
+        if (year) {
+            let count = leapdays.filter(
+                (l) => this.testLeapDay(l, year)
+            ).length;
+            return cm.length + count;
+        }
+
+        // no year, any date in this rage is plausible
+        return cm.length + leapdays.length;
+    }
+
+    /**
+     * Test if a leap day occurs in a given year.
+     */
+    testLeapDay(leapday: LeapDay, year: number) {
+        return leapday.interval
+            .sort((a, b) => a.interval - b.interval)
+            .some(({ interval, exclusive }, index, array) => {
+                if (exclusive && index == 0) {
+                    return (year - leapday.offset ?? 0) % interval != 0;
+                }
+
+                if (exclusive) return;
+
+                if (array[index + 1] && array[index + 1].exclusive) {
+                    return (
+                        (year - leapday.offset ?? 0) % interval == 0 &&
+                        (year - leapday.offset ?? 0) %
+                            array[index + 1].interval !=
+                            0
+                    );
+                }
+                return (year - leapday.offset ?? 0) % interval == 0;
+            });
+    }
+}
+
+function toMonthString(month: Nullable<number>, calendar: Calendar): string {
+    return month == null
+        ? "*"
+        : calendar.static.months[month].name;
+}
+
+function toString(data: Nullable<number>, padding: number): string {
+    return data == null
+        ? "*"
+        : String(data).padStart(padding, '0');
+}
+
+/**
+ * Convert a string/null value to null, NaN, or a number.
+ * - null or `*` are not a number, but are different than a string
+ * - if the value fails to parse as a number, it is a string month name
+ * @param data
+ * @returns null, a number, or NaN
+ */
+function wildNullNumber(data: any): Nullable<number> {
+    if (data == null || data === "*") {
+        return null;
+    }
+    if (typeof data == "number") {
+        return data;
+    }
+    return parseInt(data); // may return NaN, that's ok
+}
+
+function logError(
+    message: string,
+    input: InputDate,
+    file: { path: string; basename: string },
+    datestring?: string
+) {
+    console.log("FC Calendar: %s. From '%s', date value: %o", message, file.path, datestring ? datestring : input);
+}
+
+function logWarning(
+    message: string,
+    input: InputDate,
+    file: { path: string; basename: string },
+    datestring?: string
+) {
+    console.log("FC Calendar: %s. From '%s', date value: '%o'", message, file.path, datestring ? datestring : input);
+}

--- a/src/helper/helper.worker.ts
+++ b/src/helper/helper.worker.ts
@@ -1,11 +1,11 @@
 /** Worker for eventual offloading of calendar calculation. */
-import type { Event } from "src/@types/index";
+import type { FcEvent } from "src/@types/index";
 
 const ctx: Worker = self as any;
 
 interface EventMessage {
     type: "hash";
-    events: Event[];
+    events: FcEvent[];
 }
 
 // Respond to message from parent thread

--- a/src/helper/index.ts
+++ b/src/helper/index.ts
@@ -12,13 +12,13 @@ import type {
     Calendar,
     CurrentCalendarData,
     Month,
-    Event,
+    FcEvent,
     LeapDay,
     Moon
 } from "../@types";
 
 export class DayHelper {
-    private _events: Event[];
+    private _events: FcEvent[];
     shouldUpdate: boolean = false;
     get calendar() {
         return this.month.calendar;
@@ -30,7 +30,7 @@ export class DayHelper {
             year: this.year
         };
     }
-    get events(): Event[] {
+    get events(): FcEvent[] {
         if (!this._events || !this._events.length || this.shouldUpdate) {
             this._events = this.month.getEventsOnDay(this.date);
         }
@@ -123,7 +123,7 @@ export class MonthHelper {
     get type() {
         return this.data.type;
     }
-    events: Event[];
+    events: FcEvent[];
     getEventsOnDay(day: CurrentCalendarData) {
         if (!this.events || !this.events.length || this.shouldUpdate) {
             this.days.forEach((day) => (day.shouldUpdate = true));
@@ -213,13 +213,13 @@ export class MonthHelper {
 }
 
 interface YearEventCache {
-    events: Event[];
+    events: FcEvent[];
     shouldUpdate: boolean;
     months: Map<number, MonthHelper>;
 }
 
 export default class CalendarHelper extends Events {
-    addEvent(event: Event) {
+    addEvent(event: FcEvent) {
         const year = event.date.year;
         const month = event.date.month;
 
@@ -261,7 +261,7 @@ export default class CalendarHelper extends Events {
     /**
      * Get all the events that occur in a given month.
      */
-    getEventsForMonth(helper: MonthHelper): Event[] {
+    getEventsForMonth(helper: MonthHelper): FcEvent[] {
         //get from cache first
 
         //else

--- a/src/helper/index.ts
+++ b/src/helper/index.ts
@@ -15,7 +15,7 @@ import type {
     FcEvent,
     LeapDay,
     Moon
-} from "../@types";
+} from "src/@types";
 
 export class DayHelper {
     private _events: FcEvent[];
@@ -171,7 +171,7 @@ export class MonthHelper {
                         ) +
                         day.day;
                     const daysBetween = currentDays - startDays;
-                    
+
                     return daysBetween % event.formulas[0].number == 0;
                 }
             }

--- a/src/settings/creator/Containers/Info.svelte
+++ b/src/settings/creator/Containers/Info.svelte
@@ -93,7 +93,7 @@
         text.setValue(`${calendar.timelineTag ?? ""}`.replace("#", ""))
             .setDisabled(calendar.syncTimelines)
             .onChange(async (v) => {
-                calendar.timelineTag = v.startsWith("#") ? v : `#${v}`;
+                calendar.timelineTag = v.replace("#", "");
                 await plugin.saveSettings();
             });
         const b = new ExtraButtonComponent(node);

--- a/src/settings/import/importer.ts
+++ b/src/settings/import/importer.ts
@@ -1,8 +1,8 @@
 import type {
     Calendar,
     Era,
-    Event,
-    EventCategory,
+    FcEvent,
+    FcEventCategory,
     LeapDay,
     Month,
     Moon,
@@ -157,9 +157,9 @@ export default class Import {
                     data.dynamic_data.timespan ?? dynamicData.month;
             }
 
-            const events: Event[] = [];
+            const events: FcEvent[] = [];
 
-            const existingCategories: Map<string, EventCategory> = new Map();
+            const existingCategories: Map<string, FcEventCategory> = new Map();
             if ("categories" in data) {
                 for (let category of data.categories) {
                     const name = category.name;

--- a/src/settings/modals/event/event.ts
+++ b/src/settings/modals/event/event.ts
@@ -8,7 +8,7 @@ import {
     TextAreaComponent,
     TFile
 } from "obsidian";
-import type { Calendar, Event } from "../../../@types";
+import type { Calendar, FcEvent } from "../../../@types";
 
 import { dateString, nanoid } from "../../../utils/functions";
 
@@ -22,7 +22,7 @@ import { FantasyCalendarModal } from "../modal";
 
 export class CreateEventModal extends FantasyCalendarModal {
     saved = false;
-    event: Event = {
+    event: FcEvent = {
         name: null,
         description: null,
         date: {
@@ -49,7 +49,7 @@ export class CreateEventModal extends FantasyCalendarModal {
     constructor(
         public plugin: FantasyCalendar,
         public calendar: Calendar,
-        event?: Event,
+        event?: FcEvent,
         date?: { month: number; day: number; year: number }
     ) {
         super(plugin.app);

--- a/src/utils/presets.ts
+++ b/src/utils/presets.ts
@@ -8,7 +8,7 @@ export const PRESET_CALENDARS: Calendar[] = [
         path: "/",
         supportTimelines: false,
         syncTimelines: false,
-        timelineTag: "#timeline",
+        timelineTag: "timeline",
         static: {
             displayDayNumber: false,
             incrementDay: true,
@@ -210,7 +210,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Winter Solstice",
@@ -223,7 +227,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Spring Equinox",
@@ -236,7 +244,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Autumn Equinox",
@@ -249,7 +261,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Christmas",
@@ -262,7 +278,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 11
                 },
-                category: "christian-holidays"
+                category: "christian-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Paschal Full Moon",
@@ -275,7 +295,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: "christian-holidays"
+                category: "christian-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Easter",
@@ -288,7 +312,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: "christian-holidays"
+                category: "christian-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Easter Monday",
@@ -301,7 +329,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: "christian-holidays"
+                category: "christian-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Good Friday",
@@ -314,7 +346,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: "christian-holidays"
+                category: "christian-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Pentecost",
@@ -327,7 +363,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: "christian-holidays"
+                category: "christian-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "New Year's Day",
@@ -340,7 +380,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 0
                 },
-                category: "secular-holidays"
+                category: "secular-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Valentine's Day",
@@ -353,7 +397,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 1
                 },
-                category: "secular-holidays"
+                category: "secular-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Halloween",
@@ -366,7 +414,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 9
                 },
-                category: "secular-holidays"
+                category: "secular-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Work on the first version of this calendar started.",
@@ -379,7 +431,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: 2019,
                     month: 5
                 },
-                category: "miscellaneous-events"
+                category: "miscellaneous-events",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Work on this version of the Gregorian Calendar started.",
@@ -392,7 +448,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: 2020,
                     month: 0
                 },
-                category: "miscellaneous-events"
+                category: "miscellaneous-events",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Introduction of the Gregorian Calendar",
@@ -405,7 +465,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: 1582,
                     month: 9
                 },
-                category: "historical-events"
+                category: "historical-events",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             }
         ],
         id: null,
@@ -444,7 +508,7 @@ export const PRESET_CALENDARS: Calendar[] = [
         path: "/",
         supportTimelines: false,
         syncTimelines: false,
-        timelineTag: "#timeline",
+        timelineTag: "timeline",
         static: {
             displayDayNumber: false,
             incrementDay: false,
@@ -638,7 +702,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Spring Equinox",
@@ -651,7 +719,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Summer Solstice",
@@ -664,7 +736,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Autumn Equinox",
@@ -677,7 +753,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Great Moons Glory",
@@ -690,7 +770,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Dark Night",
@@ -703,7 +787,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Agelong",
@@ -716,7 +804,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 8
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Blood Moon Festival",
@@ -729,7 +821,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 3
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Breadgiving Day",
@@ -742,7 +838,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 0
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Brewfest",
@@ -755,7 +855,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 12
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Faerieluck",
@@ -768,7 +872,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 2
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Feast of Edoira",
@@ -781,7 +889,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 4
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Desportium of Magic",
@@ -794,7 +906,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 4
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Holy Day of Pelor",
@@ -807,7 +923,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 8
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Holy Day of Serenity",
@@ -820,7 +940,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 9
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             }
         ],
         id: null,
@@ -859,7 +983,7 @@ export const PRESET_CALENDARS: Calendar[] = [
         path: "/",
         supportTimelines: false,
         syncTimelines: false,
-        timelineTag: "#timeline",
+        timelineTag: "timeline",
         static: {
             displayDayNumber: false,
             firstWeekDay: 0,
@@ -1102,7 +1226,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Winter Solstice",
@@ -1115,7 +1243,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Spring Equinox",
@@ -1128,7 +1260,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Autumn Equinox",
@@ -1141,7 +1277,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Eternal Kiss",
@@ -1154,7 +1294,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Longnight",
@@ -1167,7 +1311,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 0
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Foundation Day",
@@ -1180,7 +1328,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 0
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Pjallarane Day",
@@ -1193,7 +1345,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 0
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Vault Day",
@@ -1206,7 +1362,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 0
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Ruby Prince's Birthday",
@@ -1219,7 +1379,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 0
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Merrymead",
@@ -1232,7 +1396,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 1
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "King Eodred II's Birthday",
@@ -1245,7 +1413,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 1
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Loyalty Day",
@@ -1258,7 +1430,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 1
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Fateless Day",
@@ -1271,7 +1447,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 1
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Golemwalk Parade",
@@ -1284,7 +1464,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 2
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Day of Bones",
@@ -1297,7 +1481,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 2
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Sable Company Founding Day",
@@ -1310,7 +1498,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 2
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Night of Tears",
@@ -1323,7 +1515,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 2
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Kaliashahrim",
@@ -1336,7 +1532,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 2
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Conquest Day",
@@ -1349,7 +1549,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 2
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Days of Wrath",
@@ -1362,7 +1566,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Firstbloom",
@@ -1375,7 +1583,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "First Cut",
@@ -1388,7 +1600,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Currentseve",
@@ -1401,7 +1617,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 3
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Taxfest",
@@ -1414,7 +1634,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 3
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Wrights of Augustana",
@@ -1427,7 +1651,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 3
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Gala of Sails",
@@ -1440,7 +1668,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 3
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Remembrance Moon",
@@ -1453,7 +1685,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 4
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Angel Day",
@@ -1466,7 +1702,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 4
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Old-Mage Day",
@@ -1479,7 +1719,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 4
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Multiple Events",
@@ -1492,7 +1736,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Burning Blades",
@@ -1505,7 +1753,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 5
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Liberty Day",
@@ -1518,7 +1770,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 5
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Talon Tag",
@@ -1531,7 +1787,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 5
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Riverwind Festival",
@@ -1544,7 +1804,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 5
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Inheritor's Ascendance ",
@@ -1557,7 +1821,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 7
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "First Crusader Day",
@@ -1570,7 +1838,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 7
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Day of Silenced Whispers",
@@ -1583,7 +1855,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 7
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Founding Day",
@@ -1596,7 +1872,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 7
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Armasse",
@@ -1609,7 +1889,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 7
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Saint Alika's Birthday",
@@ -1622,7 +1906,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 7
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Archerfeast",
@@ -1635,7 +1923,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 6
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Founding Festival",
@@ -1648,7 +1940,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 6
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Burning Night",
@@ -1661,7 +1957,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 6
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Kianidi Festival",
@@ -1674,7 +1974,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 6
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Harvest Moon",
@@ -1686,7 +1990,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 8
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Multiple Events",
@@ -1699,7 +2007,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Signing Day",
@@ -1712,7 +2024,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 8
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Crabfest",
@@ -1725,7 +2041,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 8
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Feast of Szurpade",
@@ -1738,7 +2058,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 8
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Day of Sundering",
@@ -1751,7 +2075,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 8
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Admani Upastuti",
@@ -1764,7 +2092,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 9
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Ascendance Day",
@@ -1777,7 +2109,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 9
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Bastion Day",
@@ -1790,7 +2126,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: 4712,
                     month: 9
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Jestercap",
@@ -1803,7 +2143,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 9
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Feast of the Survivors",
@@ -1816,7 +2160,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 9
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Kraken Carnival",
@@ -1829,7 +2177,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 9
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Independence Day",
@@ -1842,7 +2194,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 10
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Seven Veils",
@@ -1855,7 +2211,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 10
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Abjurant Day",
@@ -1868,7 +2228,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 10
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Great Fire Remembrance",
@@ -1881,7 +2245,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 10
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Even-Tongued Day",
@@ -1894,7 +2262,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 10
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Evoking Day",
@@ -1907,7 +2279,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 10
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Baptism of Ice",
@@ -1920,7 +2296,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 10
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Transmutatum",
@@ -1933,7 +2313,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 10
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Winter Week",
@@ -1946,7 +2330,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 11
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "The Shadowchaining",
@@ -1959,7 +2347,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 11
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Pseudodragon Festival",
@@ -1972,7 +2364,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 11
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Ascension Day",
@@ -1985,7 +2381,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 11
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Winterbloom",
@@ -1998,7 +2398,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 11
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Final Day",
@@ -2011,7 +2415,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 11
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Night of the Pale",
@@ -2024,7 +2432,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 11
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Turning Day",
@@ -2037,7 +2449,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 11
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Ritual of Stardust",
@@ -2050,7 +2466,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Planting Week",
@@ -2063,7 +2483,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Ascendance Night",
@@ -2076,7 +2500,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 4
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Azvadeva Dejal",
@@ -2089,7 +2517,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 4
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Goblin Flea Market",
@@ -2102,7 +2534,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Breaching Festival",
@@ -2115,7 +2551,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 4
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Silverglazer Sunday",
@@ -2128,7 +2568,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Batul al-Alim",
@@ -2141,7 +2585,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 1
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             }
         ],
         id: null,
@@ -2180,7 +2628,7 @@ export const PRESET_CALENDARS: Calendar[] = [
         path: "/",
         supportTimelines: false,
         syncTimelines: false,
-        timelineTag: "#timeline",
+        timelineTag: "timeline",
         static: {
             displayDayNumber: false,
             firstWeekDay: 0,
@@ -2416,7 +2864,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Revelation Day - Blood of Vol",
@@ -2429,7 +2881,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 0
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Winter Solstice",
@@ -2441,7 +2897,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 0
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Rebirth Eve - The Silver Flame",
@@ -2454,7 +2914,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 0
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Crystalfall - Sharn",
@@ -2467,7 +2931,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: 998,
                     month: 1
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Bright Souls' Day - The Silver Flame",
@@ -2480,7 +2948,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 1
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "The Day of Mourning - Sharn",
@@ -2493,7 +2965,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: 995,
                     month: 1
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Tirasday - The Silver Flame",
@@ -2506,7 +2982,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 2
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Sun's Blessing - The Sovereign Host",
@@ -2519,7 +2999,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 2
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Initiation Day - The Silver Flame",
@@ -2532,7 +3016,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 3
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Baker's Night - The Silver Flame",
@@ -2545,7 +3033,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 4
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Aureon's Crown - Sharn and The Sovereign Host",
@@ -2558,7 +3050,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 4
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Promisetide - The Silver Flame",
@@ -2571,7 +3067,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 4
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Brightblade - Sharn and The Sovereign Host",
@@ -2584,7 +3084,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 5
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "First Dawn - The Silver Flame",
@@ -2597,7 +3101,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: 915,
                     month: 5
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Silvertide - The Silver Flame",
@@ -2610,7 +3118,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 6
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "The Race of Eight Winds - Sharn",
@@ -2623,7 +3135,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: 201,
                     month: 6
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "The Hunt - Sharn and The Sovereign Host",
@@ -2636,7 +3152,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 7
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Victory Day - The Silver Flame",
@@ -2649,7 +3169,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: 881,
                     month: 7
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Fathen's Fall - Sharn",
@@ -2662,7 +3186,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: 881,
                     month: 7
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Boldrei's Feast - Sharn and The Sovereign Host",
@@ -2675,7 +3203,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 8
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "The Ascension - Sharn",
@@ -2688,7 +3220,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 9
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Wildnight - Sharn",
@@ -2701,7 +3237,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 9
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Saint Voltros's Day - The Silver Flame",
@@ -2714,7 +3254,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 9
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Thronehold - Sharn",
@@ -2727,7 +3271,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: 997,
                     month: 10
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Rampartide - The Silver Flame",
@@ -2740,7 +3288,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 10
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Long Shadows - Sharn",
@@ -2753,7 +3305,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 11
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Khybersef - The Silver Flame",
@@ -2766,7 +3322,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 11
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Spring Equinox",
@@ -2779,7 +3339,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Summer Solstice",
@@ -2792,7 +3356,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Autumn Equinox",
@@ -2805,7 +3373,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             }
         ],
         id: null,
@@ -2818,7 +3390,7 @@ export const PRESET_CALENDARS: Calendar[] = [
         path: "/",
         supportTimelines: false,
         syncTimelines: false,
-        timelineTag: "#timeline",
+        timelineTag: "timeline",
         static: {
             displayDayNumber: false,
             firstWeekDay: 0,
@@ -3019,7 +3591,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: "natural-event"
+                category: "natural-event",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Summer Solstice",
@@ -3032,7 +3608,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: "natural-event"
+                category: "natural-event",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Spring Equinox",
@@ -3045,7 +3625,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: "natural-event"
+                category: "natural-event",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Autumnal Equinox",
@@ -3058,7 +3642,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "New Year's Day",
@@ -3070,7 +3658,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Paschal Full Moon",
@@ -3083,7 +3675,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: "natural-event"
+                category: "natural-event",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             }
         ],
         id: null,
@@ -3102,7 +3698,7 @@ export const PRESET_CALENDARS: Calendar[] = [
         path: "/",
         supportTimelines: false,
         syncTimelines: false,
-        timelineTag: "#timeline",
+        timelineTag: "timeline",
         static: {
             displayDayNumber: false,
             firstWeekDay: 2,
@@ -3305,7 +3901,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Summer Solstice",
@@ -3318,7 +3918,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Autumn Equinox",
@@ -3331,7 +3935,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Winter Solstice",
@@ -3344,7 +3952,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: null
+                category: null,
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "New Dawn",
@@ -3357,7 +3969,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 0
                 },
-                category: "religious-holidays"
+                category: "religious-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Hillsgold",
@@ -3370,7 +3986,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 0
                 },
-                category: "secular-holidays"
+                category: "secular-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Day of Challenging",
@@ -3383,7 +4003,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 1
                 },
-                category: "religious-holidays"
+                category: "religious-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Renewal Festival",
@@ -3396,7 +4020,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 2
                 },
-                category: "secular-holidays"
+                category: "secular-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Wild's Grandeur",
@@ -3409,7 +4037,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 2
                 },
-                category: "religious-holidays"
+                category: "religious-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Harvest's Rise",
@@ -3422,7 +4054,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 3
                 },
-                category: "secular-holidays"
+                category: "secular-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Merryfrond's Day",
@@ -3435,7 +4071,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 3
                 },
-                category: "secular-holidays"
+                category: "secular-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Deep Solace",
@@ -3448,7 +4088,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 4
                 },
-                category: "religious-holidays"
+                category: "religious-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Zenith",
@@ -3461,7 +4105,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 4
                 },
-                category: "secular-holidays"
+                category: "secular-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Artisan's Faire",
@@ -3474,7 +4122,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 5
                 },
-                category: "secular-holidays"
+                category: "secular-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Elvendawn",
@@ -3487,7 +4139,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 5
                 },
-                category: "religious-holidays"
+                category: "religious-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Highsummer",
@@ -3500,7 +4156,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 6
                 },
-                category: "religious-holidays"
+                category: "religious-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Morn of Largesse",
@@ -3513,7 +4173,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 6
                 },
-                category: "secular-holidays"
+                category: "secular-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Harvest's Close",
@@ -3526,7 +4190,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 7
                 },
-                category: "secular-holidays"
+                category: "secular-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "The Hazel Festival",
@@ -3539,7 +4207,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 8
                 },
-                category: "secular-holidays"
+                category: "secular-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Civilization's Dawn",
@@ -3552,7 +4224,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 8
                 },
-                category: "religious-holidays"
+                category: "religious-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Night of Ascension",
@@ -3565,7 +4241,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 9
                 },
-                category: "religious-holidays"
+                category: "religious-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Zan's Cup",
@@ -3578,7 +4258,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 9
                 },
-                category: "secular-holidays"
+                category: "secular-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Barren Eve",
@@ -3591,7 +4275,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 10
                 },
-                category: "secular-holidays"
+                category: "secular-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Embertide",
@@ -3604,7 +4292,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 10
                 },
-                category: "religious-holidays"
+                category: "religious-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Winter's Crest",
@@ -3617,7 +4309,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 10
                 },
-                category: "secular-holidays"
+                category: "secular-holidays",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             }
         ],
         id: null,
@@ -3641,7 +4337,7 @@ export const PRESET_CALENDARS: Calendar[] = [
         path: "/",
         supportTimelines: false,
         syncTimelines: false,
-        timelineTag: "#timeline",
+        timelineTag: "timeline",
         static: {
             displayDayNumber: false,
             firstWeekDay: 0,
@@ -3816,7 +4512,7 @@ export const PRESET_CALENDARS: Calendar[] = [
             ],
             leapDays: [
                 {
-                    name: "Shieldsmeet",
+                    name: "Shieldmeet",
                     type: "leapday",
                     interval: [
                         {
@@ -3849,7 +4545,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: "natural-events"
+                category: "natural-events",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Vernal Equinox",
@@ -3861,7 +4561,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: "natural-events"
+                category: "natural-events",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Summer Solstice",
@@ -3873,7 +4577,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: "natural-events"
+                category: "natural-events",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Autumnal Equinox",
@@ -3885,7 +4593,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: null
                 },
-                category: "natural-events"
+                category: "natural-events",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Shieldmeet",
@@ -3898,7 +4610,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 9
                 },
-                category: "festivals"
+                category: "festivals",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Feast of the Moon",
@@ -3911,7 +4627,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 15
                 },
-                category: "festivals"
+                category: "festivals",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Highharvesttide",
@@ -3924,7 +4644,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 12
                 },
-                category: "festivals"
+                category: "festivals",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Greengrass",
@@ -3937,7 +4661,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 5
                 },
-                category: "festivals"
+                category: "festivals",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Midwinter",
@@ -3950,7 +4678,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 1
                 },
-                category: "festivals"
+                category: "festivals",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             },
             {
                 name: "Midsummer",
@@ -3963,7 +4695,11 @@ export const PRESET_CALENDARS: Calendar[] = [
                     year: null,
                     month: 9
                 },
-                category: "festivals"
+                category: "festivals",
+                sort: {
+                    timestamp: Number.MIN_VALUE,
+                    order: ''
+                }
             }
         ],
         id: null,

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -16,7 +16,7 @@ import {
     TFile,
     WorkspaceLeaf
 } from "obsidian";
-import type { Calendar, CurrentCalendarData, Event } from "src/@types";
+import type { Calendar, CurrentCalendarData, FcEvent } from "src/@types";
 import type { DayHelper } from "src/helper";
 import CalendarHelper from "src/helper";
 import { CreateEventModal } from "src/settings/modals/event/event";
@@ -357,7 +357,7 @@ export default class FantasyCalendarView extends ItemView {
 
         this._app.$on(
             "event-click",
-            (evt: CustomEvent<{ event: Event; modifier: boolean }>) => {
+            (evt: CustomEvent<{ event: FcEvent; modifier: boolean }>) => {
                 const { event, modifier } = evt.detail;
                 if (event.note) {
                     let leaves: WorkspaceLeaf[] = [];
@@ -385,7 +385,7 @@ export default class FantasyCalendarView extends ItemView {
 
         this._app.$on(
             "event-mouseover",
-            (evt: CustomEvent<{ target: HTMLElement; event: Event }>) => {
+            (evt: CustomEvent<{ target: HTMLElement; event: FcEvent }>) => {
                 if (!this.plugin.data.eventPreview) return;
                 const { target, event } = evt.detail;
                 if (event.note) {
@@ -402,7 +402,7 @@ export default class FantasyCalendarView extends ItemView {
 
         this._app.$on(
             "event-context",
-            (custom: CustomEvent<{ evt: MouseEvent; event: Event }>) => {
+            (custom: CustomEvent<{ evt: MouseEvent; event: FcEvent }>) => {
                 const { evt, event } = custom.detail;
 
                 const menu = new Menu(this.app);
@@ -837,7 +837,7 @@ class ChangeDateModal extends FantasyCalendarModal {
 }
 
 class ViewEventModal extends FantasyCalendarModal {
-    constructor(public event: Event, public plugin: FantasyCalendar) {
+    constructor(public event: FcEvent, public plugin: FantasyCalendar) {
         super(plugin.app);
         this.containerEl.addClass("fantasy-calendar-view-event");
     }

--- a/src/watcher/watcher.ts
+++ b/src/watcher/watcher.ts
@@ -8,7 +8,7 @@ import {
     getAllTags,
     FuzzySuggestModal
 } from "obsidian";
-import type { Calendar, Event } from "src/@types";
+import type { Calendar, FcEvent } from "src/@types";
 import type FantasyCalendar from "src/main";
 //have to ignore until i fix typing issue
 //@ts-expect-error
@@ -319,7 +319,7 @@ export class Watcher extends Component {
         }
         this.startParsing([...folders]);
     }
-    addToTree(calendar: Calendar, event: Event) {
+    addToTree(calendar: Calendar, event: FcEvent) {
         if (!this.tree.has(calendar.id)) {
             this.tree.set(calendar.id, new Set());
         }

--- a/src/watcher/watcher.worker.ts
+++ b/src/watcher/watcher.worker.ts
@@ -1,5 +1,5 @@
 import type { CachedMetadata, FrontMatterCache } from "obsidian";
-import type { Calendar, CurrentCalendarData, Event } from "src/@types";
+import type { Calendar, CurrentCalendarData, FcEvent } from "src/@types";
 import { nanoid, wrap } from "src/utils/functions";
 const { DOMParser } = require("xmldom");
 
@@ -35,14 +35,14 @@ export interface UpdateEventMessage {
     type: "update";
     id: string;
     index: number;
-    event: Event;
-    original: Event;
+    event: FcEvent;
+    original: FcEvent;
 }
 export interface DeleteEventMessage {
     type: "delete";
     id: string;
     index: number;
-    event: Event;
+    event: FcEvent;
 }
 
 export interface SaveMessage {
@@ -219,7 +219,7 @@ class Parser {
             return;
         }
 
-        let timelineEvents: Event[] = [];
+        let timelineEvents: FcEvent[] = [];
         if (
             calendar.supportTimelines &&
             allTags &&
@@ -296,7 +296,7 @@ class Parser {
         frontmatter: FrontMatterCache,
         file: { path: string; basename: string },
         eventDisplayName?: string
-    ): Event[] {
+    ): FcEvent[] {
         const { date, end } = this.getDates(
             frontmatter,
             this.parseTitle ? file.basename : ""
@@ -356,7 +356,7 @@ class Parser {
         file: { path: string; basename: string },
         fcCategory: string
     ) {
-        const events: Event[] = [];
+        const events: FcEvent[] = [];
         const domparser = new DOMParser();
         // span or div with attributes:
         // <span

--- a/src/watcher/watcher.worker.ts
+++ b/src/watcher/watcher.worker.ts
@@ -1,7 +1,6 @@
 import type { CachedMetadata, FrontMatterCache } from "obsidian";
-import type { Calendar, CurrentCalendarData, FcEvent } from "src/@types";
-import { nanoid, wrap } from "src/utils/functions";
-const { DOMParser } = require("xmldom");
+import type { Calendar, FcEvent, Nullable } from "src/@types";
+import { FcEventHelper } from "src/helper/event.helper";
 
 export interface QueueMessage {
     type: "queue";
@@ -55,7 +54,6 @@ export type RenameMessage = {
     file: { path: string; basename: string; oldPath: string };
 };
 
-const timelineData: RegExp = /(<(span|div).*?<\/(span|div)>)/g;
 const ctx: Worker = self as any;
 class Parser {
     queue: string[] = [];
@@ -66,6 +64,7 @@ class Parser {
     parseTitle: boolean = false;
     addToDefaultIfMissing: boolean;
     debug: boolean;
+    eventHelpers = new Map();
 
     constructor() {
         //Register Options Changer
@@ -166,23 +165,6 @@ class Parser {
             ctx.postMessage<GetFileCacheMessage>({ path, type: "get" });
         });
     }
-    getDataFromFrontmatter(frontmatter: FrontMatterCache) {
-        let name: string, fcCategory: string, eventDisplayName: string;
-        if (frontmatter && "fc-ignore" in frontmatter) return {};
-        if (frontmatter) {
-            name = frontmatter?.["fc-calendar"];
-            fcCategory = frontmatter?.["fc-category"];
-            eventDisplayName = frontmatter?.["fc-display-name"];
-        }
-        if (this.addToDefaultIfMissing && (!name || !name.length)) {
-            name = this.defaultCalendar;
-        }
-        name = name?.toLowerCase();
-        const calendar = this.calendars.find(
-            (calendar) => name == calendar.name.toLowerCase()
-        );
-        return { calendar, fcCategory, eventDisplayName };
-    }
     removeEventsFromFile(path: string) {
         for (const calendar of this.calendars) {
             for (let i = 0; i < calendar.events.length; i++) {
@@ -203,280 +185,77 @@ class Parser {
         allTags: string[],
         file: { path: string; basename: string }
     ) {
-        const events = [];
         const { frontmatter } = cache ?? {};
 
-        const { calendar, fcCategory, eventDisplayName } =
-            this.getDataFromFrontmatter(frontmatter);
+        // Always clear existing events for a changed file
+        this.removeEventsFromFile(file.path);
 
-        if (!calendar) {
-            if (this.debug) {
-                console.info(
-                    `Could not find calendar associated with file ${file.basename}`
-                );
-            }
-            this.removeEventsFromFile(file.path);
-            return;
+        const eventHelper = this.createEventHandler(frontmatter, file);
+        if (!eventHelper) {
+            return; // no calendar for this file, events removed
         }
 
-        let timelineEvents: FcEvent[] = [];
-        if (
-            calendar.supportTimelines &&
-            allTags &&
-            allTags
-                .map((tag) => tag.replace(/#/, ""))
-                .includes(calendar.timelineTag.replace(/#/, ""))
-        ) {
-            timelineEvents = this.parseTimelineEvents(
-                calendar,
-                data,
-                file,
-                fcCategory
-            );
-            events.push(...timelineEvents);
-        }
+        let fEvents = 0;
+        let tEvents = 0;
 
-        const frontmatterEvents = this.parseFrontmatterEvents(
-            calendar,
-            fcCategory,
-            frontmatter,
-            file,
-            eventDisplayName
-        );
-
-        events.push(...frontmatterEvents);
-        if (!events || !events.length) {
-            this.removeEventsFromFile(file.path);
-            return;
-        }
-
-        let added = 0;
-        for (const event of events) {
-            //TODO: Remove event existing check. Old events matching the file should just be removed.
-            const existing = calendar.events.find(
-                (exist) =>
-                    exist.note == file.path &&
-                    (!event.timestamp || exist.timestamp == event.timestamp)
-            );
-            if (
-                existing?.date.day == event.date.day &&
-                existing?.date.month == event.date.month &&
-                existing?.date.year == event.date.year &&
-                existing?.end?.day == event.end?.day &&
-                existing?.end?.month == event.end?.month &&
-                existing?.end?.year == event.end?.year &&
-                existing?.category == event.category &&
-                existing?.name == event.name &&
-                ((!event.timestamp && !existing?.timestamp) ||
-                    existing?.timestamp == event.timestamp)
-            ) {
-                continue;
-            }
-
+        eventHelper.parseFrontmatterEvent(frontmatter, file, (event: FcEvent) => {
             ctx.postMessage<UpdateEventMessage>({
                 type: "update",
-                id: calendar.id,
-                index: existing
-                    ? calendar.events.findIndex((e) => e.id == existing?.id)
-                    : -1,
+                id: eventHelper.calendar.id,
+                index: -1,
                 event,
-                original: existing
+                original: undefined
             });
-            added++;
+            fEvents++;
+        });
+
+        if (
+            eventHelper.calendar.supportTimelines &&
+            allTags &&
+            allTags.includes(eventHelper.calendar.timelineTag)
+        ) {
+            eventHelper.parseTimelineEvents(data, file, (event: FcEvent) => {
+                ctx.postMessage<UpdateEventMessage>({
+                    type: "update",
+                    id: eventHelper.calendar.id,
+                    index: -1,
+                    event,
+                    original: undefined
+                });
+                tEvents++;
+            });
         }
-        if (this.debug && events.length > 0) {
+
+
+        if (this.debug && fEvents + tEvents > 0) {
             console.info(
-                `${added}/${events.length} (${frontmatterEvents.length} from frontmatter, ${timelineEvents.length} from timelines) event operations completed on ${calendar.name} for ${file.basename}`
+                `${fEvents} frontmatter and ${tEvents} timeline event operations completed on ${eventHelper.calendar.name} for ${file.basename}`
             );
         }
     }
-    parseFrontmatterEvents(
-        calendar: Calendar,
-        fcCategory: string,
-        frontmatter: FrontMatterCache,
-        file: { path: string; basename: string },
-        eventDisplayName?: string
-    ): FcEvent[] {
-        const { date, end } = this.getDates(
-            frontmatter,
-            this.parseTitle ? file.basename : ""
-        );
-        if (!date) {
-            return [];
-        }
-
-        if (date?.month && typeof date?.month == "string") {
-            let month = calendar.static.months.find(
-                (m) => m.name == (date.month as unknown as string)
-            );
-            if (!month) {
-                date.month = null;
-            } else {
-                date.month = calendar.static.months.indexOf(month);
+    createEventHandler(frontmatter: FrontMatterCache, file: { path: string; basename: string }): Nullable<FcEventHelper> {
+        if (frontmatter && ! frontmatter["fc-ignore"]) {
+            let name = frontmatter?.["fc-calendar"];
+            if (this.addToDefaultIfMissing && (!name || !name.length)) {
+                name = this.defaultCalendar;
             }
-        } else if (date?.month && typeof date?.month == "number") {
-            date.month = wrap(date.month - 1, calendar.static.months.length);
-        }
-
-        if (end?.month && typeof end?.month == "string") {
-            let month = calendar.static.months.find(
-                (m) => m.name == (end.month as unknown as string)
-            );
-            if (!month) {
-                end.month = null;
-            } else {
-                end.month = calendar.static.months.indexOf(month);
+            name = name?.toLowerCase();
+            let helper = this.eventHelpers.get(name);
+            if (!helper) {
+                const calendar = this.calendars.find(
+                    (calendar) => name == calendar.name.toLowerCase()
+                );
+                if (!calendar && this.debug) {
+                    console.info(
+                        `Could not find calendar associated with file ${file.basename}`
+                    );
+                    return null;
+                }
+                helper = new FcEventHelper(calendar, this.parseTitle, this.format);
             }
-        } else if (end?.month && typeof end?.month == "number") {
-            end.month = wrap(end.month - 1, calendar.static.months.length);
+            return helper;
         }
-
-        const timestamp = Number(`${date.year}${date.month}${date.day}00`);
-
-        const category = calendar.categories.find(
-            (cat) => cat?.name == fcCategory
-        );
-
-        return [
-            {
-                id: nanoid(6),
-                name: eventDisplayName ?? file.basename,
-                note: file.path,
-                date,
-                end,
-                category: category?.id,
-                description: "",
-                auto: true
-            }
-        ];
-    }
-    parseTimelineEvents(
-        calendar: Calendar,
-        contents: string,
-        file: { path: string; basename: string },
-        fcCategory: string
-    ) {
-        const events: FcEvent[] = [];
-        const domparser = new DOMParser();
-        // span or div with attributes:
-        // <span
-        //     class='ob-timelines'
-        //     data-date='144-43-49-00'
-        //     data-title='Another Event'
-        //     data-class='orange'
-        //     data-img = 'Timeline Example/Timeline_2.jpg'
-        //     data-type='range'
-        //     data-end="2000-10-20-00">
-        //     A second event!
-        // </span>
-        for (const match of contents.matchAll(timelineData)) {
-            const doc = domparser.parseFromString(match[0], "text/html");
-            const element = {
-                class: doc.documentElement.getAttribute("class"),
-                dataset: {
-                    date: doc.documentElement.getAttribute("data-date"),
-                    title: doc.documentElement.getAttribute("data-title"),
-                    class: doc.documentElement.getAttribute("data-class"),
-                    end: doc.documentElement.getAttribute("data-end")
-                },
-                content: doc.documentElement.textContent
-            };
-
-            if (element.class !== "ob-timelines" || !element.dataset.date) {
-                continue; // only look at elements with a date and class='ob-timelines'
-            }
-
-            // smash together the yyyy-mm-dd-hh string (accounting for negative years) to use as an id
-            const timestamp = Number(
-                element.dataset.date[0] == "-"
-                    ? +element.dataset.date
-                          .substring(1, element.dataset.date.length)
-                          .split("-")
-                          .join("") * -1
-                    : +element.dataset.date.split("-").join("")
-            );
-
-            let datebits = element.dataset.date.split(/(?<!^)-/);
-            const date = {
-                year: parseInt(datebits[0]),
-                month: parseInt(datebits[1]),
-                day: parseInt(datebits[2])
-            };
-            let end;
-            if (element.dataset.end) {
-                datebits = element.dataset.end.split(/(?<!^)-/);
-                end = {
-                    year: parseInt(datebits[0]),
-                    month: parseInt(datebits[1]),
-                    day: parseInt(datebits[2])
-                };
-            }
-            const category = calendar.categories.find(
-                (cat) => cat?.name == element.dataset.class ?? fcCategory
-            );
-
-            events.push({
-                id: nanoid(6),
-                name: element.dataset.title ?? file.basename,
-                note: file.path,
-                date,
-                end,
-                timestamp,
-                category: category?.id,
-                description: element.content,
-                auto: true
-            });
-        }
-        return events;
-    }
-    parseDate(date: string | CurrentCalendarData) {
-        if (typeof date === "string") {
-            if (!/\d+[./-]\d+[./-]\d+/.test(date)) return;
-            try {
-                const [match] = date.match(/\d+[./-]\d+[./-]\d+/) ?? [];
-                if (!match) return;
-                const split = match.split(/[.\-\/]/).map((d) => Number(d));
-
-                const formatter = [
-                    ...new Set(
-                        this.format
-                            .replace(/[^\w]/g, "")
-                            .toUpperCase()
-                            .split("")
-                    )
-                ];
-
-                return {
-                    year: split[formatter.indexOf("Y")],
-                    month: split[formatter.indexOf("M")],
-                    day: split[formatter.indexOf("D")]
-                };
-            } catch (e) {
-                return;
-            }
-        } else {
-            return date;
-        }
-    }
-    getDates(frontmatter: Partial<FrontMatterCache> = {}, basename: string) {
-        const dateField = "fc-date" in frontmatter ? "fc-date" : "fc-start";
-        let startDate: string | CurrentCalendarData;
-        if (frontmatter && dateField in frontmatter) {
-            startDate = frontmatter[dateField];
-        }
-        if (!startDate) {
-            startDate = basename;
-        }
-
-        const date = this.parseDate(startDate);
-
-        const endDate =
-            "fc-end" in frontmatter
-                ? (frontmatter["fc-end"] as string | CurrentCalendarData)
-                : null;
-        const end = this.parseDate(endDate);
-
-        return { date, end };
+        return null;
     }
 }
 new Parser();

--- a/test/event.parseAltFormat.test.ts
+++ b/test/event.parseAltFormat.test.ts
@@ -1,0 +1,62 @@
+import { FcEventDate } from "../src/@types";
+import { FcEventHelper, ParseDate } from "../src/helper/event.helper";
+import { PRESET_CALENDARS } from "../src/utils/presets";
+
+const GREGORIAN = PRESET_CALENDARS.find((p) => p.name == "Gregorian Calendar");
+const file = {
+    path: "path",
+    basename: "basename"
+}
+
+const input: FcEventDate = {
+    year: 1400,
+    month: 1,
+    day: 28
+};
+
+test("YYYY-MM-DD", () => {
+    const YMD = new FcEventHelper(GREGORIAN, true, 'YYYY-MM-DD');
+    const datestring = '1400-02-28';
+    expect(YMD.formatDigest).toEqual('YMD');
+    expect(YMD.toFcDateString(input)).toEqual(datestring);
+    expect(YMD.parseFcDateString(datestring, file)).toEqual(expect.objectContaining(input));
+});
+test("YYYY-MMM-DD", () => {
+    const YMD = new FcEventHelper(GREGORIAN, true, 'YYYY-MMM-DD');
+    const datestring = '1400-February-28';
+    expect(YMD.formatDigest).toEqual('YMD');
+    expect(YMD.toFcDateString(input)).toEqual(datestring);
+    expect(YMD.parseFcDateString(datestring, file)).toEqual(expect.objectContaining(input));
+});
+
+test("M-D-Y", () => {
+    const MDY = new FcEventHelper(GREGORIAN, true, 'M-D-Y');
+    const datestring = "2-28-1400";
+    expect(MDY.formatDigest).toEqual('MDY');
+    expect(MDY.toFcDateString(input)).toEqual(datestring);
+    expect(MDY.parseFcDateString(datestring, file)).toEqual(expect.objectContaining(input));
+});
+
+test("MM-D-Y", () => {
+    const MDY = new FcEventHelper(GREGORIAN, true, 'MM-D-Y');
+    const datestring = "02-28-1400";
+    expect(MDY.formatDigest).toEqual('MDY');
+    expect(MDY.toFcDateString(input)).toEqual(datestring);
+    expect(MDY.parseFcDateString(datestring, file)).toEqual(expect.objectContaining(input));
+});
+
+test("DD-M-Y", () => {
+    const DMY = new FcEventHelper(GREGORIAN, true, 'DD-M-Y');
+    const datestring = "28-2-1400";
+    expect(DMY.formatDigest).toEqual('DMY');
+    expect(DMY.toFcDateString(input)).toEqual(datestring);
+    expect(DMY.parseFcDateString(datestring, file)).toEqual(expect.objectContaining(input));
+});
+
+test("DD-MMM-Y", () => {
+    const DMY = new FcEventHelper(GREGORIAN, true, 'DD-MMM-Y');
+    const datestring = "28-February-1400";
+    expect(DMY.formatDigest).toEqual('DMY');
+    expect(DMY.toFcDateString(input)).toEqual(datestring);
+    expect(DMY.parseFcDateString(datestring, file)).toEqual(expect.objectContaining(input));
+});

--- a/test/event.parseFcString.gregorian.test.ts
+++ b/test/event.parseFcString.gregorian.test.ts
@@ -1,0 +1,87 @@
+import { FcEventHelper, ParseDate } from "../src/helper/event.helper";
+import { PRESET_CALENDARS } from "../src/utils/presets";
+
+const GREGORIAN = PRESET_CALENDARS.find((p) => p.name == "Gregorian Calendar");
+const helper = new FcEventHelper(GREGORIAN, false, 'YYYY-MM-DD');
+const file = {
+    path: "path",
+    basename: "basename"
+}
+
+// test("Leap Days (Gregorian)", () => {
+//     expect(leapDaysBeforeYear(1, GREGORIAN)).toBe(0);
+//     expect(leapDaysBeforeYear(5, GREGORIAN)).toBe(1);
+//     expect(leapDaysBeforeYear(9, GREGORIAN)).toBe(2);
+//     expect(leapDaysBeforeYear(100, GREGORIAN)).toBe(24);
+//     expect(leapDaysBeforeYear(401, GREGORIAN)).toBe(97);
+//     expect(leapDaysBeforeYear(2022, GREGORIAN)).toBe(490);
+// });
+
+test("Parse January", () => {
+    const expected: ParseDate = {
+        year: 0,
+        month: 0,
+        day: 1,
+        order: ''
+    };
+    // Mess around with year 0 for fun
+    expect(helper.parseFcDateString("0", file)).toEqual(expected);
+    expect(helper.parseFcDateString("0-01", file)).toEqual(expected);
+    expect(helper.parseFcDateString("0-01-01", file)).toEqual(expected);
+    expect(helper.parseFcDateString("0-Jan", file)).toEqual(expected);
+    expect(helper.parseFcDateString("0-January-01", file)).toEqual(expected);
+});
+test("Parse February", () => {
+    const expected: ParseDate = {
+        year: 0,
+        month: 1,
+        day: 1,
+        order: ''
+    };
+    expect(helper.parseFcDateString("0-02", file)).toEqual(expected);
+    expect(helper.parseFcDateString("0-02-01", file)).toEqual(expected);
+    expect(helper.parseFcDateString("0-Feb", file)).toEqual(expected);
+    expect(helper.parseFcDateString("0-February-01", file)).toEqual(expected);
+    // brought into range
+    expect(helper.parseFcDateString("0-02-00", file)).toEqual(expected);
+    // Bad day
+    expect(helper.parseFcDateString("1900-Feb-30", file)).toBeNull();
+});
+test("Parse February: Leap year", () => {
+    const expected: ParseDate = {
+        year: 0,
+        month: 1,
+        day: 29,
+        order: ''
+    };
+
+    // Leap years
+    expect(helper.parseFcDateString("1996-February-29", file)).toEqual({
+        ...expected,
+        year: 1996
+    });
+    expect(helper.parseFcDateString("1600-February-29", file)).toEqual({
+        ...expected,
+        year: 1600
+    });
+    expect(helper.parseFcDateString("2000-February-29", file)).toEqual({
+        ...expected,
+        year: 2000
+    });
+    // Not leap years
+    expect(helper.parseFcDateString("1700-Feb-29", file)).toBeNull();
+    expect(helper.parseFcDateString("1800-Feb-29", file)).toBeNull();
+    expect(helper.parseFcDateString("1900-Feb-29", file)).toBeNull();
+});
+test("Parse March", () => {
+    const expected: ParseDate = {
+        year: 0,
+        month: 2,
+        day: 31,
+        order: 'some extra'
+    };
+    // Mess around with year 0 for fun
+    expect(helper.parseFcDateString("0-03-31-some extra", file)).toEqual(expected);
+    expect(helper.parseFcDateString("0-Mar-31-some extra", file)).toEqual(expected);
+    expect(helper.parseFcDateString("0-March-31-some extra", file)).toEqual(expected);
+});

--- a/test/event.parseFcString.harptos.test.ts
+++ b/test/event.parseFcString.harptos.test.ts
@@ -1,0 +1,184 @@
+import { LeapDay } from "../src/@types/calendar";
+import { FcEventHelper, ParseDate } from "../src/helper/event.helper";
+import { PRESET_CALENDARS } from "../src/utils/presets";
+
+const HARPTOS = PRESET_CALENDARS.find((p) => p.name == "Calendar of Harptos");
+const helper = new FcEventHelper(HARPTOS, false, 'YYYY-MM-DD');
+const file = {
+    path: "path",
+    basename: "basename"
+}
+
+// index | fc-date | calendar reckoning | Month name
+//  0 |  1 |  1 | Hammer
+//  1 |  2 |  - | Midwinter
+//  2 |  3 |  2 | Alturiak
+//  3 |  4 |  3 | Ches
+//  4 |  5 |  4 | Tarsakh
+//  5 |  6 |  - | Greengrass
+//  6 |  7 |  5 | Mirtul
+//  7 |  8 |  6 | Kythorn
+//  8 |  9 |  7 | Flamerule
+//  9 | 10 |  - | Midsummer (Shieldmeet)
+// 10 | 11 |  8 | Elesias
+// 11 | 12 |  9 | Eleint
+// 12 | 13 |  - | Highharvestide
+// 13 | 14 | 10 | Marpenoth
+// 14 | 15 | 11 | Uktar
+// 15 | 16 |  - | Feast of the Moon
+// 16 | 17 | 12 | Nightal
+
+test("daysForMonth", () => {
+    expect(helper.daysForMonth(0,  1499)).toEqual(30);
+    expect(helper.daysForMonth(1,  1499)).toEqual(1);
+    expect(helper.daysForMonth(5,  1499)).toEqual(1);
+    expect(helper.daysForMonth(9,  1499)).toEqual(1);
+    expect(helper.daysForMonth(9,  1372)).toEqual(2);
+    expect(helper.daysForMonth(12, 1499)).toEqual(1);
+    expect(helper.daysForMonth(16, 1499)).toEqual(30);
+});
+
+//  0 |  1 |  1 | Hammer
+test("Parse Harptos: 1499-01, Hammer", () => {
+    const expected: ParseDate = {
+        year: 1499,
+        month: 0,
+        day: 1,
+        order: ''
+    };
+    expect(helper.parseFcDateString("1499", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-01", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-01-01", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-Hammer", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-Hammer-01", file)).toEqual(expected);
+});
+//  1 |  2 |  - | Midwinter
+test("Parse Harptos: 1499-02, Midwinter", () => {
+    const expected: ParseDate = {
+        year: 1499,
+        month: 1, // Midwinter
+        day: 1,
+        order: ''
+    };
+    expect(helper.parseFcDateString("1499-02", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-02-01", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-Midwinter", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-Midwinter-01", file)).toEqual(expected);
+    // Midwinter has only one day...
+    expect(helper.parseFcDateString("1499-02-03", file)).toBeNull();
+});
+//  2 |  3 |  2 | Alturiak
+test("Parse Harptos: 1499-03, Alturiak", () => {
+    const expected: ParseDate = {
+        year: 1499,
+        month: 2, // month numbers line up for Alturiak (2), Ches (3), Tarsahk (4)
+        day: 1,
+        order: ''
+    };
+    expect(helper.parseFcDateString("1499-03", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-03-01", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-Alturiak", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-Alturiak-01", file)).toEqual(expected);
+});
+//  3 |  4 |  3 | Ches
+//  4 |  5 |  4 | Tarsakh
+//  5 |  6 |  - | Greengrass
+test("Parse Harptos: 1499-06, Greengrass", () => {
+    const expected: ParseDate = {
+        year: 1499,
+        month: 5, // Greengrass
+        day: 1,
+        order: ''
+    }
+    expect(helper.parseFcDateString("1499-06", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-06-01", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-Greengrass", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-Greengrass-01", file)).toEqual(expected);
+    // Greengrass has only one day...
+    expect(helper.parseFcDateString("1499-06-03", file)).toBeNull();
+});
+//  6 |  7 |  5 | Mirtul
+test("Parse Harptos: 1499-06, Mirtul", () => {
+    const expected: ParseDate = {
+        year: 1499,
+        month: 6,
+        day: 1,
+        order: ''
+    }
+    expect(helper.parseFcDateString("1499-07", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-07-01", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-Mir", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-Mirtul-01", file)).toEqual(expected);
+});
+//  7 |  8 |  6 | Kythorn
+//  8 |  9 |  7 | Flamerule
+//  9 | 10 |  - | Midsummer (Shieldmeet)
+test("Parse Harptos: 1499-09, Midsummer", () => {
+    const expected: ParseDate = {
+        year: 1499,
+        month: 9,
+        day: 1,
+        order: ''
+    }
+    expect(helper.parseFcDateString("1499-10", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-10-01", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-Midsum", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-Midsummer-01", file)).toEqual(expected);
+});
+test("Parse Harptos: 1372-Shieldmeet", () => {
+    const expected: ParseDate = {
+        year: 1372,
+        month: 9,
+        day: 2,
+        order: ''
+    }
+    expect(helper.parseFcDateString("1372-10-02", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1372-Shieldmeet", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1372-Shieldmeet-02", file)).toEqual(expected);
+    // Shieldmeet is a leapday
+    expect(helper.parseFcDateString("1499-10-02", file)).toBeNull();
+
+});
+// 10 | 11 |  8 | Eleasis
+test("Parse Harptos: 1499-11, Eleasis", () => {
+    const expected: ParseDate = {
+        year: 1499,
+        month: 10,
+        day: 1,
+        order: ''
+    }
+    expect(helper.parseFcDateString("1499-11", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-11-01", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-Eleas", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-Eleasis-01", file)).toEqual(expected);
+});
+// 11 | 12 |  9 | Eleint
+// 12 | 13 |  - | Highharvestide
+test("Parse Harptos: 1499-13, Highharvestide", () => {
+    const expected: ParseDate = {
+        year: 1499,
+        month: 12,
+        day: 1,
+        order: ''
+    }
+    expect(helper.parseFcDateString("1499-13", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-13-01", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-High", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-Highharvestide-01", file)).toEqual(expected);
+});
+// 13 | 14 | 10 | Marpenoth
+test("Parse Harptos: 1499-14, Marpenoth", () => {
+    const expected: ParseDate = {
+        year: 1499,
+        month: 13,
+        day: 1,
+        order: ''
+    }
+    expect(helper.parseFcDateString("1499-14", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-14-01", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-Marp", file)).toEqual(expected);
+    expect(helper.parseFcDateString("1499-Marpenoth-01", file)).toEqual(expected);
+});
+// 14 | 15 | 11 | Uktar
+// 15 | 16 |  - | Feast of the Moon
+// 16 | 17 | 12 | Nightal

--- a/test/event.parseFunctions.test.ts
+++ b/test/event.parseFunctions.test.ts
@@ -1,0 +1,232 @@
+import { Loc, Pos } from "obsidian";
+import { FcEvent } from "../src/@types";
+import { FcEventHelper, ParseDate } from "../src/helper/event.helper";
+import { PRESET_CALENDARS } from "../src/utils/presets";
+
+const GREGORIAN = PRESET_CALENDARS.find((p) => p.name == "Gregorian Calendar");
+const gregorian = new FcEventHelper(GREGORIAN, true, 'YYYY-MM-DD');
+
+const file = {
+    path: "path",
+    basename: "1966-04"
+}
+const loc: Loc = {
+    line: 0,
+    col: 0,
+    offset: 0
+}
+const position: Pos = {
+    start: loc,
+    end: loc
+}
+
+test("Bad Year", () => {
+    expect(gregorian.parseFcDateString("", file)).toBeNull();
+});
+
+test("Timestamp", () => {
+    const expected: ParseDate = {
+        year: 1966,
+        month: 3,
+        day: 1,
+        order: ''
+    };
+
+    expect(gregorian.padDays).toEqual(2);
+    expect(gregorian.padMonth).toEqual(2);
+    expect(gregorian.parsedToTimestamp(expected)).toEqual({
+        timestamp: 19660301,
+        order: ''
+    })
+});
+
+test("parseFrontmatterDate / parseFilename", () => {
+    const expected: ParseDate = {
+        year: 1966,
+        month: 3,
+        day: 1,
+        order: ''
+    };
+    // read date string from frontmatter
+    expect(gregorian.parseFrontmatterDate("1966-04", file)).toEqual(expected);
+
+    // read date from filename
+    expect(gregorian.parseFilenameDate({
+        ...file,
+        basename: "1966-04"
+    })).toEqual(expected);
+
+    // read date from object
+    expect(gregorian.parseFrontmatterDate({
+            year: 1966,
+            month: 4,
+            day: 1
+        }, file)).toEqual(expected);
+});
+
+test("parseFrontmatterDate / parseFilenameDate: extra", () => {
+    const expected: ParseDate = {
+        year: 1966,
+        month: 3,
+        day: 1,
+        order: '01 some extra flavor'
+    };
+    // read date string from frontmatter
+    expect(gregorian.parseFrontmatterDate(
+        "1966-04-01-01 some extra flavor", file)).toEqual(expected);
+
+    // read date from filename
+    expect(gregorian.parseFilenameDate({
+        ...file,
+        basename: "1966-04-01-01 some extra flavor"
+    })).toEqual(expected);
+
+    // read date from object
+    expect(gregorian.parseFrontmatterDate({
+            year: 1966,
+            month: 4,
+            day: 1,
+            order: '01 some extra flavor'
+        }, file)).toEqual(expected);
+});
+
+test("parseFrontmatterEvent", () => {
+    let category = gregorian.calendar.categories[0];
+    let actual: FcEvent[] = [];
+
+    gregorian.parseFrontmatterEvent({
+            "fc-start": "1966-05-23",
+            "fc-end": {
+                year: 1966,
+                month: 8,
+                day: 1
+            },
+            "fc-display-name": "Pretty name",
+            "fc-description": "Fun text",
+            "fc-img": "attachments/thing.png",
+            position
+        }, file,
+        (event) => { actual.push(event)},
+        category
+    );
+
+    expect(actual.length).toEqual(1);
+    expect(actual[0].id).toBeDefined();
+    expect(actual[0].name).toEqual("Pretty name");
+    expect(actual[0].description).toEqual("Fun text");
+    expect(actual[0].date).toEqual(expect.objectContaining({
+        year: 1966,
+        month: 4, // 0-index
+        day: 23
+    }));
+    expect(actual[0].end).toEqual(expect.objectContaining(
+        {
+        year: 1966,
+        month: 7,
+        day: 1
+    }));
+    expect(actual[0].sort).toEqual({
+        timestamp: 19660423,
+        order: ''
+    });
+    expect(actual[0].note).toEqual(file.path);
+    expect(actual[0].category).toEqual(category.id);
+    expect(actual[0].img).toEqual("attachments/thing.png");
+});
+
+test("parseTimelineEvent", () => {
+    let category = gregorian.calendar.categories[0];
+    let actual: FcEvent[] = [];
+
+    gregorian.parseTimelineEvents(
+        "<span class='ob-timelines'   \n" +
+        " data-category='natural-events' \n" +
+        " data-fc-date='1966-05-23-00'\n" +
+        " data-fc-end='1966-08-1-00'  \n" +
+        " data-img='attachments/thing.png'  \n" +
+        " data-title='Pretty name'>\n" +
+        "Fun text" +
+        "</span>",
+        file,
+        (event) => { actual.push(event)},
+        category
+    );
+
+    expect(actual.length).toEqual(1);
+    expect(actual[0].id).toBeDefined();
+    expect(actual[0].name).toEqual("Pretty name");
+    expect(actual[0].description.trim()).toEqual("Fun text");
+    expect(actual[0].date).toEqual(expect.objectContaining({
+        year: 1966,
+        month: 4, // 0-index
+        day: 23
+    }));
+    expect(actual[0].end).toEqual(expect.objectContaining(
+        {
+        year: 1966,
+        month: 7,
+        day: 1
+    }));
+    expect(actual[0].sort).toEqual({
+        timestamp: 19660423,
+        order: '00'
+    });
+    expect(actual[0].note).toEqual(file.path);
+    expect(actual[0].category).toEqual(category.id);
+    expect(actual[0].img).toEqual("attachments/thing.png");
+});
+
+test("Repeating events", () => {
+    const expected: ParseDate = {
+        year: null,
+        month: null,
+        day: null,
+        order: ''
+    };
+    expect(gregorian.parseFcDateString("*-*-*", file)).toEqual(expected);
+
+    expect(gregorian.parseFrontmatterDate({}, file)).toEqual(expected);
+
+    expect(gregorian.parsedToTimestamp(expected)).toEqual({
+        timestamp: Number.MIN_VALUE,
+        order: "*-*-*"
+    })
+});
+
+test("Repeating events with extra", () => {
+    const expected: ParseDate = {
+        year: null,
+        month: null,
+        day: null,
+        order: '01 some extra flavor'
+    };
+    expect(gregorian.parseFcDateString("*-*-*-01 some extra flavor", file)).toEqual(expected);
+
+    expect(gregorian.parseFrontmatterDate({
+            order: '01 some extra flavor'
+        }, file)).toEqual(expected);
+
+    expect(gregorian.parsedToTimestamp(expected)).toEqual({
+        timestamp: Number.MIN_VALUE,
+        order: '01 some extra flavor'
+    })
+});
+
+test("Repeating events with extra", () => {
+    const expected: ParseDate = {
+        year: null,
+        month: null,
+        day: null,
+        order: '01 some extra flavor'
+    };
+    expect(gregorian.parseFcDateString("*-*-*-01 some extra flavor", file)).toEqual(expected);
+
+    expect(gregorian.parseFrontmatterDate({
+            order: '01 some extra flavor'
+        }, file)).toEqual(expected);
+
+    expect(gregorian.parsedToTimestamp(expected)).toEqual({
+        timestamp: Number.MIN_VALUE,
+        order: '01 some extra flavor'
+    })
+});


### PR DESCRIPTION
Resolves #97 

Given a Timeline span or div with attributes:

```
<span
    class='ob-timelines'          // ignored (obsidian timelines plugin format)
    data-type='range'             // ignored (obsidian timelines plugin format)
    data-date='144-43-49-00'      // ignored (obsidian timelines plugin format)
    data-end='2000-10-20-00'      // ignored (obsidian timelines plugin format)
    data-fc-date='144-Ches'       // FC: short/mixed (day, hour assumed 0)
    data-fc-end='144-Ches-03-07'  // FC: long/mixed
    data-title='Another Event'
    data-class='orange'
    data-img = 'Timeline Example/Timeline_2.jpg'>
    Event description
</span>
```

FC Timeline date form has at most 4 segments. THey always starts with the year: yyyy-(mm|mmm)-dd-hh.
