### PR TITLE
Updated README with instructions for building from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ After installing the plugin, you can use `npm` to build new `main.js` and `style
 -   Open the source directory in your terminal and run `npm install`.
 -   Running `npm run build` will build the `main.js` and `styles.css` files inside the source directory.
 -   Navigate to your `fantasy-calendar` folder in your vault's plugins folder and replace the `main.js` and `styles.css` files with the newly generated ones.
--   Reload Obsidian to use the new files.
+-   Reload Obsidian to use the new files. This can be done automatically with the [Hot-Reload Plugin for Obsidian](https://github.com/pjeby/hot-reload).
 
 You can alternatively use the `npm run dev` command for a more streamlined workflow if you set up your `.env` file first.
 
@@ -488,7 +488,7 @@ You can alternatively use the `npm run dev` command for a more streamlined workf
 OUTDIR="/absolute/path/to/your/vault/.obsidian/plugins/fantasy-calendar"
 ```
 -   In the source directory, run `npm run dev`. This builds the `main.js` and `styles.css` files and puts them in the folder you specified in your `.env` file.
--   The `dev` script will automatically rebuild those files whenever you save changes. Simply reload Obsidian to see your changes!
+-   The `dev` script will automatically rebuild those files whenever you save changes.
 
 # Warning
 

--- a/README.md
+++ b/README.md
@@ -471,6 +471,25 @@ In the meantime, the plugin may be installed via the [Obsidian BRAT plugin](http
 
 You can follow the same procedure to update the plugin.
 
+### Building from Source
+
+After installing the plugin, you can use `npm` to build new `main.js` and `styles.css` files from source.
+
+-   Open the source directory in your terminal and run `npm install`.
+-   Running `npm run build` will build the `main.js` and `styles.css` files inside the source directory.
+-   Navigate to your `fantasy-calendar` folder in your vault's plugins folder and replace the `main.js` and `styles.css` files with the newly generated ones.
+-   Reload Obsidian to use the new files.
+
+You can alternatively use the `npm run dev` command for a more streamlined workflow if you set up your `.env` file first.
+
+-   Open the source directory and create a file called `.env`.
+-   Add the following line to the file:
+```
+OUTDIR="/absolute/path/to/your/vault/.obsidian/plugins/fantasy-calendar"
+```
+-   In the source directory, run `npm run dev`. This builds the `main.js` and `styles.css` files and puts them in the folder you specified in your `.env` file.
+-   The `dev` script will automatically rebuild those files whenever you save changes. Simply reload Obsidian to see your changes!
+
 # Warning
 
 This plugin comes with no guarantee of stability and bugs may delete data.


### PR DESCRIPTION
## What's in this PR?

This PR adds instructions to the README on how to build the plugin from source code. This was requested on the Fantasy Computerworks Discord server by PalladiumTurtle: **[link to post](https://discord.com/channels/399974878134140939/1099881140883554355)**

Feel free to make any changes to how these instructions are worded. Thanks for your time!
